### PR TITLE
Consider as_json options :only and :except for setting accessors

### DIFF
--- a/lib/setting_accessors/integration.rb
+++ b/lib/setting_accessors/integration.rb
@@ -104,9 +104,17 @@ module SettingAccessors::Integration
     self
   end
 
-  def as_json(*)
-    json = super
-    SettingAccessors::Internal.setting_accessor_names(self.class).each do |setting_name|
+  def as_json(options = {})
+    json = super options
+
+    setting_names = SettingAccessors::Internal.setting_accessor_names(self.class)
+    if only = options[:only]
+      setting_names &= Array(only).map(&:to_s)
+    elsif except = options[:except]
+      setting_names -= Array(except).map(&:to_s)
+    end
+
+    setting_names.each do |setting_name|
       json[setting_name.to_s] = send(setting_name)
     end
     json

--- a/test/dummy/test/models/user_test.rb
+++ b/test/dummy/test/models/user_test.rb
@@ -17,6 +17,48 @@ class UserTest < ActiveSupport::TestCase
         assert_equal @user.as_json[setting_name.to_s], @user.send(setting_name)
       end
     end
+
+    context 'when using as_json with option :only' do
+      context 'set to a class attribute name' do
+        should 'not include any setting accessors' do
+          json = @user.as_json :only => [:first_name]
+          SettingAccessors::Internal.setting_accessor_names(User).each do |setting_name|
+            assert_not_includes json.keys, setting_name
+          end
+        end
+      end
+
+      context 'set to a setting accessor name' do
+        should 'not include other setting accessors' do
+          json = @user.as_json :only => [:a_string]
+          assert_includes json.keys, 'a_string'
+          (SettingAccessors::Internal.setting_accessor_names(User) - ['a_string']).each do |setting_name|
+            assert_not_includes json.keys, setting_name
+          end
+        end
+      end
+    end
+
+    context 'when using as_json with option :except' do
+      context 'set to a class attribute name' do
+        should 'include all setting accessors' do
+          json = @user.as_json :except => [:first_name]
+          SettingAccessors::Internal.setting_accessor_names(User).each do |setting_name|
+            assert_includes json.keys, setting_name
+          end
+        end
+      end
+
+      context 'set to a setting accessor name' do
+        should 'include all other setting accessors' do
+          json = @user.as_json :except => [:a_string]
+          assert_not_includes json.keys, 'a_string'
+          (SettingAccessors::Internal.setting_accessor_names(User) - ['a_string']).each do |setting_name|
+            assert_includes json.keys, setting_name
+          end
+        end
+      end
+    end
   end
 
   context 'Boolean getter methods' do


### PR DESCRIPTION
When using `as_json` on a model instance which has setting_accessors defined,
the options `:only` and `:except` should be considered for the setting accessors
as well.

```ruby

# Model
class User < ActiveRecord::Base
  setting_accessor :a_string, :fallback => :default
  setting_accessor :a_number, :fallback => :global
  setting_accessor :a_boolean, :fallback => false
end

# rails console
# NB: created_at and updated_at are omitted here
> u = User.first
 => #<User id: 1, first_name: "Peter", last_name: "Parker", [...]>

> u.a_string = "a setting accessor"
> u.save

> u.as_json
 => {"id"=>1, "first_name"=>"Peter", "last_name"=>"Parker", [...],
     "a_string"=>"a setting accessor", "a_number"=>nil, "a_boolean"=>false}

# --- before changes by this commit ---
# setting accessors are not expected here
> u.as_json only: :first_name
 => {"first_name"=>"Peter", "a_string"=>"a setting accessor", "a_number"=>nil,
     "a_boolean"=>false}

# setting accessors should be included here
> u.as_json except: :first_name
 => {"id"=>1, "last_name"=>"Parker", [...], a_string"=>"a setting accessor",
     "a_number"=>nil, "a_boolean"=>false}

# only one setting accessor should be included here
> u.as_json only: :a_string
 => {"a_string"=>"a setting accessor", "a_number"=>nil, "a_boolean"=>false}

# `a_string` setting accessor should be excluded here
> u.as_json except: :a_string
 => {"id"=>1, "first_name"=>"Peter", "last_name"=>"Parker", [...],
     "a_string"=>"a setting accessor", "a_number"=>nil, "a_boolean"=>false}

# --- after changes by this commit ---
# setting accessors are not expected here
> u.as_json only: :first_name
 => {"first_name"=>"Peter"}

# setting accessors should be included here (no change)
> u.as_json except: :first_name
 => {"id"=>1, "last_name"=>"Parker", [...], "a_string"=>"a setting accessor",
     "a_number"=>nil, "a_boolean"=>false}

# only one setting accessor should be included here
> u.as_json only: :a_string
 => {"a_string"=>"a setting accessor"}

# `a_string` setting accessor should be excluded here
> u.as_json except: :a_string
 => {"id"=>1, "first_name"=>"Peter", "last_name"=>"Parker", [...],
     "a_number"=>nil, "a_boolean"=>false}

```