### PR TITLE
Create setting accessors even if the table is not initialized yet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ tmp
 *.a
 mkmf.log
 
-#Rubymine
-.idea
+# RVM
+.ruby-version
 
 #Dummy Application
 test/dummy/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.2
   - 2.3.1
 
+env:
+  - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+
 before_install: 'gem install bundler'
 script: 'bundle exec rake'
 

--- a/lib/setting_accessors/integration.rb
+++ b/lib/setting_accessors/integration.rb
@@ -36,20 +36,11 @@ module SettingAccessors::Integration
     #   setting and return +nil+ if none was specified previously.
     #
     def setting_accessor(setting_name, options = {})
-      #If the database table does not yet exist,
-      return unless self.table_exists?
-
       fallback = options.delete(:fallback)
 
       SettingAccessors::Internal.set_class_setting(self, setting_name, options)
 
-      setting_type = SettingAccessors::Internal.setting_value_type(setting_name, self.new).to_sym
-
-      #Create a virtual column in the models column hash.
-      #This is currently not absolutely necessary, but will become important once
-      #Time etc. are supported. Otherwise, Rails won't be able to e.g. automatically
-      #create multi-param fields in forms.
-      self.columns_hash[setting_name.to_s] = OpenStruct.new(type: setting_type)
+      setting_type = SettingAccessors::Internal.setting_value_type(setting_name, self).to_sym
 
       #Add the setting's name to the list of setting_accessors for this class
       SettingAccessors::Internal.add_setting_accessor_name(self, setting_name)

--- a/lib/setting_accessors/internal.rb
+++ b/lib/setting_accessors/internal.rb
@@ -76,8 +76,12 @@ module SettingAccessors
     #   - If it's a setting defined in a setting_accessor call, the information is taken from this call
     #   - Otherwise, an empty hash is returned
     #
-    def self.setting_data(setting_name, assignable = nil)
-      (assignable && self.get_class_setting(assignable.class, setting_name)) ||
+    def self.setting_data(setting_name, assignable_class = nil)
+      # As a convenience function (and to keep the existing code working),
+      # it is possible to provide a class or an instance of said class
+      assignable_class &&= assignable_class.class unless assignable_class.is_a?(Class)
+
+      (assignable_class && self.get_class_setting(assignable_class, setting_name)) ||
           self.global_config[setting_name.to_s] ||
           {}
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,14 @@ if ActiveSupport::TestCase.method_defined?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end
 
+# configure shoulda matchers
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :minitest
+    with.library :rails
+  end
+end
+
 # For generators
 require "rails/generators/test_case"
 require "generators/setting_accessors/install_generator"


### PR DESCRIPTION
Closes #6 

---

With this PR, `setting_accessor` calls in models will create the corresponding accessor methods even if the model's database table does not yet exist.

It also removes pushing type information into the model's `columns_hash` as it was never used anyway, had the wrong format for newer rails versions and could even lead to errors regarding auto type casting done by active record.