### PR TITLE
Fix NoMethodError if callback is conditional and aborts using throw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
 
-before_install: 'gem install bundler'
+before_install: 'gem install bundler -v 1.17.3'
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/lib/setting_accessors/integration.rb
+++ b/lib/setting_accessors/integration.rb
@@ -83,7 +83,9 @@ module SettingAccessors
       def _update_record(*)
         super.tap do |affected_rows|
           # Workaround to trigger a #touch if necessary, see +after_save+ callback further up
-          @_setting_accessors_touch_assignable = affected_rows.zero?
+          # The callback chain can, if a filter was provided for a certain callback and the callback throws and :abort,
+          # return +false+ instead of a number so we have to address both cases here.
+          @_setting_accessors_touch_assignable = (affected_rows == false) || affected_rows.zero?
         end
       end
     end

--- a/spec/lib/setting_accessors/integration_spec.rb
+++ b/spec/lib/setting_accessors/integration_spec.rb
@@ -104,7 +104,8 @@ describe SettingAccessors::Integration, type: :model do
         end
 
         def i_hate_johns
-          throw(:abort)
+          Gem.loaded_specs['activerecord'].version >= Gem::Version.create('5.1') &&
+            throw(:abort)
         end
       end
     end

--- a/spec/lib/setting_accessors/integration_spec.rb
+++ b/spec/lib/setting_accessors/integration_spec.rb
@@ -96,11 +96,29 @@ describe SettingAccessors::Integration, type: :model do
 
       model do
         setting_accessor :string_setting, type: :string
+
+        before_update :i_hate_johns, if: :johns_here
+
+        def johns_here
+          string_attribute == 'john'
+        end
+
+        def i_hate_johns
+          throw(:abort)
+        end
       end
     end
 
     let!(:record) do
       TestModel.create(string_attribute: 'string_value', string_setting: 'string_setting_value', updated_at: 1.day.ago)
+    end
+
+    context 'when an update is not valid and aborted using the abort symbol' do
+      let(:update) { -> { record.update_attributes(string_attribute: 'john') } }
+
+      it 'does not raise an error' do
+        expect(update).not_to raise_error
+      end
     end
 
     shared_examples 'attribute update and touch' do |attribute_name|


### PR DESCRIPTION
Added a test and a fix for an issue where `_update_record` may return
`false` instead of a number if one of the callbacks has a "filter" (so a
conditional if: or unless: key) and does a `throw(:abort)` to halt the
callback sequence.

This error is caused in

/activesupport/lib/active_support/callbacks.rb:130

but since it is part of the internal API there is no sense in reporting
that issue.