### PR TITLE
Release/2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
 
-before_install: 'gem install bundler'
+before_install: 'gem install bundler -v 1.17.3'
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 1.2.0
+## [2.0.0] - 2019-09-27
+
+New major version as the change to the `touch` behavior might break existing apps
+and therefore is not backwards compatible.
+
+### Fixed
+
+- For AR >= 5.1, records are no longer `touch`ed after saving if
+  - [#19] the lifecycle was halted using `throw(:abort)` (props to @Haniyya)
+  - [#20] neither attributes nor settings were changed (basically `Model.first.save`)
+
+## [1.2.0]
 
 This is a major bugfix release as the gem was basically broken when being installed in a fresh Rails 5 application.
 
@@ -20,7 +31,7 @@ This is a major bugfix release as the gem was basically broken when being instal
 * Calls to `#as_json` as well as probably other parts of the AR API would fail if the gem was only included
   but not used (#17)
 
-## 1.1.0
+## [1.1.0]
 
 A bugfix and slight refactoring release which takes care of several issues regarding
 changing setting-values in-place without actually setting them before. (#13)
@@ -28,7 +39,7 @@ changing setting-values in-place without actually setting them before. (#13)
 * More and better specs
 * Better handling of non-existent settings through exception handling rather than multiple error prone tests
 
-## 1.0.0
+## [1.0.0]
 
 This is almost a complete refactoring of the gem which also removes some not really needed functionality.  
 It is the first release fully compatible with Rails 5.  
@@ -65,6 +76,6 @@ New minimum versions:
 * `setting_accessor` no longer supports the `fallback` option.  
    If a `default` option is given, it is automatically used as fallback.
 
-## 0.3.0
+## [0.3.0]
 
 * Fixed a bug that caused setting accessors not being initialized when being called as part of a rake task chain (#6)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and ActiveRecord integration to add virtual columns to models without having to 
 Version Information / Backwards Compatibility
 ---------------------------------------------
 
-The current version (1.x) is only compatible with Ruby >= 2.3 and Rails >= 4.2.  
+The current version (2.x) is only compatible with Ruby >= 2.3 and Rails >= 4.2.  
 Versions 0.x support older versions of both Ruby and Rails. 
 
 Version 0.x also supported validations and type conversions for globally defined settings

--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ validates :my_string, presence: true
 validates :my_number, numericality: {only_integer: true}
 ```
 
+Contributors
+------------
+
+<a href="https://github.com/stex/setting_accessors/graphs/contributors">
+  <img src="https://contributors-img.firebaseapp.com/image?repo=stex/setting_accessors" />
+</a>
+
+Made with [contributors-img](https://contributors-img.firebaseapp.com).
+
 Contributing
 ------------
 

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    setting_accessors (1.2.0)
+    setting_accessors (2.0.0)
       rails (>= 4.2, < 5.3)
 
 GEM

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    setting_accessors (1.2.0)
+    setting_accessors (2.0.0)
       rails (>= 4.2, < 5.3)
 
 GEM

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    setting_accessors (1.2.0)
+    setting_accessors (2.0.0)
       rails (>= 4.2, < 5.3)
 
 GEM

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    setting_accessors (1.2.0)
+    setting_accessors (2.0.0)
       rails (>= 4.2, < 5.3)
 
 GEM

--- a/lib/setting_accessors/integration.rb
+++ b/lib/setting_accessors/integration.rb
@@ -83,7 +83,9 @@ module SettingAccessors
       def _update_record(*)
         super.tap do |affected_rows|
           # Workaround to trigger a #touch if necessary, see +after_save+ callback further up
-          @_setting_accessors_touch_assignable = affected_rows.zero?
+          # The callback chain can, if a filter was provided for a certain callback and the callback throws and :abort,
+          # return +false+ instead of a number so we have to address both cases here.
+          @_setting_accessors_touch_assignable = (affected_rows == false) || affected_rows.zero?
         end
       end
     end

--- a/lib/setting_accessors/integration.rb
+++ b/lib/setting_accessors/integration.rb
@@ -82,10 +82,12 @@ module SettingAccessors
     if Gem.loaded_specs['activerecord'].version >= Gem::Version.create('5.1')
       def _update_record(*)
         super.tap do |affected_rows|
-          # Workaround to trigger a #touch if necessary, see +after_save+ callback further up
           # The callback chain can, if a filter was provided for a certain callback and the callback throws and :abort,
           # return +false+ instead of a number so we have to address both cases here.
-          @_setting_accessors_touch_assignable = (affected_rows == false) || affected_rows.zero?
+          unless affected_rows == false
+            # Workaround to trigger a #touch if necessary, see +after_save+ callback further up
+            @_setting_accessors_touch_assignable = affected_rows.zero? && settings.changed_settings.present?
+          end
         end
       end
     end

--- a/lib/setting_accessors/version.rb
+++ b/lib/setting_accessors/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SettingAccessors
-  VERSION = '1.2.0'
+  VERSION = '2.0.0'
 end

--- a/spec/lib/setting_accessors/integration_spec.rb
+++ b/spec/lib/setting_accessors/integration_spec.rb
@@ -110,16 +110,10 @@ describe SettingAccessors::Integration, type: :model do
       end
     end
 
+    let(:initial_updated_at) { 1.day.ago }
+
     let!(:record) do
-      TestModel.create(string_attribute: 'string_value', string_setting: 'string_setting_value', updated_at: 1.day.ago)
-    end
-
-    context 'when an update is not valid and aborted using the abort symbol' do
-      let(:update) { -> { record.update_attributes(string_attribute: 'john') } }
-
-      it 'does not raise an error' do
-        expect(update).not_to raise_error
-      end
+      TestModel.create(string_attribute: 'string_value', string_setting: 'string_setting_value', updated_at: initial_updated_at)
     end
 
     shared_examples 'attribute update and touch' do |attribute_name|
@@ -129,6 +123,12 @@ describe SettingAccessors::Integration, type: :model do
 
       it 'updates the +updated_at+ column accordingly' do
         expect(TestModel.find(record.id).updated_at).to be_within(5.seconds).of(Time.now)
+      end
+    end
+
+    shared_examples 'no touch' do
+      it 'does not alter the +updated_at+ column' do
+        expect(TestModel.find(record.id).updated_at).to eql initial_updated_at
       end
     end
 
@@ -148,10 +148,24 @@ describe SettingAccessors::Integration, type: :model do
         include_examples 'attribute update and touch', attribute_name
       end
 
-      context 'using mass assignment (update_attributes)' do
+      context 'using mass assignment (#update_attributes)' do
         before(:each) { record.update_attributes(attribute_name => 'Poiski') }
 
         include_examples 'attribute update and touch', attribute_name
+      end
+    end
+
+    context 'when nothing was changed at all' do
+      context 'and using #save' do
+        before(:each) { record.save! }
+
+        include_examples 'no touch'
+      end
+
+      context 'and using mass assignment (#update_attributes)' do
+        before(:each) { record.update_attributes({}) }
+
+        include_examples 'no touch'
       end
     end
 
@@ -161,6 +175,16 @@ describe SettingAccessors::Integration, type: :model do
 
     context 'when only a setting was changed' do
       include_examples 'attribute setter variations', :string_setting
+    end
+
+    context 'when an update is not valid and aborted using the abort symbol' do
+      before(:each) { record.update_attributes(string_attribute: 'john', string_setting: 'jane') }
+
+      it 'does not alter setting values' do
+        expect(record.reload.string_setting).to eql 'string_setting_value'
+      end
+
+      include_examples 'no touch'
     end
   end
 

--- a/spec/lib/setting_accessors/integration_spec.rb
+++ b/spec/lib/setting_accessors/integration_spec.rb
@@ -104,7 +104,8 @@ describe SettingAccessors::Integration, type: :model do
         end
 
         def i_hate_johns
-          throw(:abort)
+          Gem.loaded_specs['activerecord'].version >= Gem::Version.create('5.1') &&
+            throw(:abort)
         end
       end
     end

--- a/spec/lib/setting_accessors/integration_spec.rb
+++ b/spec/lib/setting_accessors/integration_spec.rb
@@ -128,7 +128,7 @@ describe SettingAccessors::Integration, type: :model do
 
     shared_examples 'no touch' do
       it 'does not alter the +updated_at+ column' do
-        expect(TestModel.find(record.id).updated_at).to eql initial_updated_at
+        expect(TestModel.find(record.id).updated_at.to_i).to eql initial_updated_at.to_i
       end
     end
 

--- a/spec/lib/setting_accessors/integration_spec.rb
+++ b/spec/lib/setting_accessors/integration_spec.rb
@@ -96,11 +96,29 @@ describe SettingAccessors::Integration, type: :model do
 
       model do
         setting_accessor :string_setting, type: :string
+
+        before_update :i_hate_johns, if: :johns_here
+
+        def johns_here
+          string_attribute == 'john'
+        end
+
+        def i_hate_johns
+          throw(:abort)
+        end
       end
     end
 
     let!(:record) do
       TestModel.create(string_attribute: 'string_value', string_setting: 'string_setting_value', updated_at: 1.day.ago)
+    end
+
+    context 'when an update is not valid and aborted using the abort symbol' do
+      let(:update) { -> { record.update_attributes(string_attribute: 'john') } }
+
+      it 'does not raise an error' do
+        expect(update).not_to raise_error
+      end
     end
 
     shared_examples 'attribute update and touch' do |attribute_name|


### PR DESCRIPTION
## [2.0.0] - 2019-09-27

New major version as the change to the `touch` behavior might break existing apps
and therefore is not backwards compatible.

### Fixed

- For AR >= 5.1, records are no longer `touch`ed after saving if
  - [#19] the lifecycle was halted using `throw(:abort)` (props to @Haniyya)
  - [#20] neither attributes nor settings were changed (basically `Model.first.save`)
